### PR TITLE
fix(sqlalchemy): replace heroku url

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -13,7 +13,11 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 fileConfig(config.config_file_name)
-config.set_section_option("alembic", "sqlalchemy.url", os.environ.get("DATABASE_URL"))
+config.set_section_option(
+    "alembic",
+    "sqlalchemy.url",
+    os.environ.get("DATABASE_URL").replace("postgres://", "postgresql://"),
+)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/src/longpoll.py
+++ b/src/longpoll.py
@@ -19,7 +19,9 @@ from src.crash import send_crash_email
 
 load_dotenv()
 
-manager = DatabaseManager(os.environ.get("DATABASE_URL"))
+manager = DatabaseManager(
+    os.environ.get("DATABASE_URL").replace("postgres://", "postgresql://")
+)
 vk_session = vk_api.VkApi(token=os.environ.get("ACCESS_TOKEN"))
 longpoll = VkBotLongPoll(vk_session, os.environ.get("GROUP_ID"))
 vk = vk_session.get_api()


### PR DESCRIPTION
By default, Heroku database env variable starts with `postgres://...` but recent versions of SQLAlchemy require it to begin with `postgresql://...`.
A little hack is introduced to adapt to this behavior